### PR TITLE
Fix message for big sample groups

### DIFF
--- a/R/ntest.R
+++ b/R/ntest.R
@@ -65,7 +65,7 @@ ntest <- function(df, cols) {
   if (any(sample_sizes$n > 5000)) {
     cli::cli_abort(c(
       "Sample size of all groups needs to be <= 5000.",
-      i = "Groups with n < 3: {.strong {big_sample_names}}.")
+      i = "Groups with n > 5000: {.strong {big_sample_names}}.")
     )
   }
 


### PR DESCRIPTION
## Summary
- correct the CLI info string when samples exceed 5000 in size

## Testing
- `Rscript -e 'library(devtools); devtools::test()'` *(fails: install_r4np uses disallowed package installs)*

------
https://chatgpt.com/codex/tasks/task_e_688a35cb4fc08325bd0ba861071b314b