### PR TITLE
Fix create_project_folder directory handling

### DIFF
--- a/R/create_project_folder.R
+++ b/R/create_project_folder.R
@@ -4,17 +4,23 @@
 #'     folder structure in the working directory of your R session.
 #' @export
 create_project_folder <- function() {
-  base::dir.create("00_raw_data")
-  base::dir.create("01_tidy_data")
-  base::dir.create("02_r_scripts")
-  base::dir.create("03_plots")
-  base::dir.create("04_reports")
-  base::dir.create("99_other")
-  message(paste("The following directories have been created in: ", getwd(), ".", sep=""))
-  message("- 00_raw_data")
-  message("- 01_tidy_data")
-  message("- 02_r_scripts")
-  message("- 03_plots")
-  message("- 04_reports")
-  message("- 99_other")
+  dirs <- c(
+    "00_raw_data",
+    "01_tidy_data",
+    "02_r_scripts",
+    "03_plots",
+    "04_reports",
+    "99_other"
+  )
+
+  for (d in dirs) {
+    if (!base::dir.exists(d)) {
+      base::dir.create(d, showWarnings = FALSE)
+    }
+  }
+
+  message(paste("The following directories have been created in: ", getwd(), ".", sep = ""))
+  for (d in dirs) {
+    message(paste("-", d))
+  }
 }


### PR DESCRIPTION
## Summary
- avoid warnings when project folder already exists by checking `dir.exists`

## Testing
- `devtools::test()`

------
https://chatgpt.com/codex/tasks/task_e_688a359c60d083258f741e21d2d9effb