### PR TITLE
Validate numeric columns in ntest functions

### DIFF
--- a/R/ntest.R
+++ b/R/ntest.R
@@ -11,8 +11,10 @@
 #'  calculates the sample size for each variable. It then checks if the sample
 #'  size for any variable is less than 3 or greater than 5000, and if so, aborts
 #'  the function with an error message because the `shapiro.test()` only expects
-#'  this range of observations. The function then performs the Shapiro-Wilk test
-#'  on each variable and returns a formatted dataframe with the test results.
+#'  this range of observations. The function also verifies that all selected
+#'  columns are numeric and aborts otherwise. The function then performs the
+#'  Shapiro-Wilk test on each variable and returns a formatted dataframe with the
+#'  test results.
 #'
 #' @return A dataframe with the test results. Each row corresponds to a variable,
 #'  and the columns contain the test statistics and p-values.
@@ -62,11 +64,23 @@ ntest <- function(df, cols) {
     )
   }
 
+
   if (any(sample_sizes$n > 5000)) {
     cli::cli_abort(c(
       "Sample size of all groups needs to be <= 5000.",
       i = "Groups with n < 3: {.strong {big_sample_names}}.")
     )
+  }
+
+  # Check that selected columns are numeric
+  selected <- df |> select({{ cols }})
+  are_numeric <- purrr::map_lgl(selected, is.numeric)
+  if (any(!are_numeric)) {
+    invalid <- paste(names(selected)[!are_numeric], collapse = ", ")
+    cli::cli_abort(c(
+      "All selected columns must be numeric.",
+      i = "Non-numeric columns: {.strong {invalid}}."
+    ))
   }
 
   # Performing normality test

--- a/R/ntest_by.R
+++ b/R/ntest_by.R
@@ -10,11 +10,12 @@
 #'
 #' @details The function first creates subsets of the data for each group. It
 #'   then performs a Shapiro-Wilk normality test (`shapiro.test()`) on each
-#'   group and returns the results in a tidy format. the function also checks
+#'   group and returns the results in a tidy format. The function also checks
 #'   whether the number of observations for each variable and group lies within
-#'   the permissible range of the `shapiro.test()`. If not, the function will
-#'   provide diagnostics on why a test could not be performed base on which
-#'   groups are affected.
+#'   the permissible range of the `shapiro.test()` and verifies that all
+#'   selected columns are numeric. If any of these conditions are violated, the
+#'   function will provide diagnostics on why a test could not be performed and
+#'   which groups or variables are affected.
 #'
 #' @return A data frame with the results of the Shapiro-Wilk test for each group
 #'   and variable.
@@ -42,6 +43,17 @@
 #'
 #' @export
 ntest_by <- function(df, cols, group){
+
+  # Check that selected columns are numeric
+  selected <- df |> select({{ cols }})
+  are_numeric <- purrr::map_lgl(selected, is.numeric)
+  if (any(!are_numeric)) {
+    invalid <- paste(names(selected)[!are_numeric], collapse = ", ")
+    cli::cli_abort(c(
+      "All selected columns must be numeric.",
+      i = "Non-numeric columns: {.strong {invalid}}."
+    ))
+  }
 
 # Create subsets of data as nested dfs
 nested_group_data <-

--- a/tests/testthat/test-ntest.R
+++ b/tests/testthat/test-ntest.R
@@ -11,6 +11,13 @@ test_that("ntest rejects incorrect input types", {
   expect_error(ntest(df, cols = 1:2))
 })
 
+test_that("ntest aborts when selected columns are not numeric", {
+  df <- data.frame(a = rnorm(10),
+                   b = letters[1:10])
+
+  expect_error(ntest(df, cols = c(a, b)), "All selected columns must be numeric")
+})
+
 test_that("ntest aborts when n < 3", {
   df <- data.frame(a = rnorm(2),
                    b = rnorm(2))

--- a/tests/testthat/test-ntest_by.R
+++ b/tests/testthat/test-ntest_by.R
@@ -21,6 +21,17 @@ test_that("ntest_by rejects incorrect input types", {
                         cols = 1:2))
 })
 
+test_that("ntest_by aborts when selected columns are not numeric", {
+  non_num_df <- data.frame(
+    group = rep(c("A", "B"), each = 5),
+    col1 = rnorm(10),
+    col2 = letters[1:10]
+  )
+
+  expect_error(ntest_by(non_num_df, c(col1, col2), group),
+               "All selected columns must be numeric")
+})
+
 test_that("ntest_by returns the correct number of rows", {
   result <- ntest_by(df, c(col1, col2, col3), group)
   expect_equal(nrow(result), 12) # 4 groups * 3 columns


### PR DESCRIPTION
## Summary
- check for numeric columns in `ntest()` and `ntest_by()`
- clarify docs about numeric requirement
- test that non‐numeric columns cause an error

## Testing
- `R -q -e "testthat::test_dir('tests/testthat')"` *(fails: there is no package called ‘testthat’)*

------
https://chatgpt.com/codex/tasks/task_e_688a2ee27e988325abf5ecf7de0738bd