### PR TITLE
Add CRAN skip to install test

### DIFF
--- a/tests/testthat/test-install_r4np.R
+++ b/tests/testthat/test-install_r4np.R
@@ -1,3 +1,6 @@
+skip_on_cran()
+skip_if_offline()
+
 test_that("install_r4np installs packages", {
   # Run the function
   install_r4np()


### PR DESCRIPTION
## Summary
- skip `test-install_r4np` when running on CRAN or offline

## Testing
- ❌ `R -q -e devtools::test()` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a2f68b13483259343c4a06807ef55